### PR TITLE
Make require 'plaid-legacy' work

### DIFF
--- a/lib/plaid-legacy.rb
+++ b/lib/plaid-legacy.rb
@@ -1,0 +1,1 @@
+require 'plaid'


### PR DESCRIPTION
With this, a simple 

```ruby
gem 'plaid-legacy'
```
should work, not making people use

```ruby
gem 'plaid-legacy', require: 'plaid'
```
Fixes #4 